### PR TITLE
Transforma lista de participantes em tabela

### DIFF
--- a/PARTICIPANTS.md
+++ b/PARTICIPANTS.md
@@ -1,39 +1,41 @@
 # Participantes
 
-- eduhenke - https://github.com/eduhenke/rinha-de-compiler
-- eduOliver - https://github.com/Edu0liver/Rinha-Compiler
-- henri - https://github.com/hnrbs/rinha
-- edusporto - https://github.com/edusporto/rinha-compilador
-- losty17 - https://github.com/Losty17/rinha-de-compiler
-- rodrigocam - https://github.com/rodrigocam/rinha
-- ricardopieper - https://github.com/ricardopieper/rinha-compiler
-- adilsxn - https://github.com/adilsxn/rinha-de-compiler
-- leonardohn - https://github.com/leonardohn/rinha-interpreter
-- lucasmontano - https://github.com/lucasmontano/rinha-de-compiler
-- D4yvid - https://github.com/D4yvid/compiler-rinha
-- Olordecoelho - https://github.com/olordecoelho/rinha-de-compiladores
-- DouglasGabr - https://github.com/DouglasGabr/rinha-de-compiler
-- milyth - https://github.com/milyth/touka
-- italo - https://github.com/ZyllDev/rinha-compiler
-- astahjmo e niumxp - https://github.com/astahjmo/rinha-de-compiler
-- andrecoelho - https://github.com/andrecoelhoa/rinha-interpreter-app
-- Emanuel Júnior - https://github.com/VetusScientia/rinha-de-compiler
-- Lamadelrae - https://github.com/Lamadelrae/compiler-battles-csharp
-- rwillians_ - https://github.com/rwillians/rinha-de-compiladores--gambi-elixir
-- wilgnne - https://github.com/wilgnne/rinha-de-compiler-ts
-- BRonen - https://github.com/BRonen/luajit-rinha-de-compiler
-- netodotcom - https://github.com/netodotcom/rinha-de-compiler
-- mr-soulfox - https://github.com/mr-soulfox/rinha-de-compiladores-cpp
-- Crazynds - https://github.com/crazynds/rinha-compiler
-- reonardoleis - https://github.com/reonardoleis/nargas
-- Yazalde Filimone - https://github.com/yazaldefilimonepinto/rinha-compiler
-- PedroFnseca - https://github.com/PedroFnseca/rinha-compiler-rust
-- guilhermedjr - https://github.com/guilhermedjr/rinha-compiler-csharp
-- dhrleandro - https://github.com/dhrleandro/rinha-de-compiler-php
-- brunokim - https://github.com/brunokim/rinha-de-compiler
-- matheusgb - https://github.com/matheusgb/marmota
-- lrlucena - https://github.com/lrlucena/rinha-de-compiler-scala
-- fernandozanutto - https://github.com/fernandozanutto/rinha-compiler
-- fenner - https://github.com/alexandrofenner/rinha-compiladores-2023
-- dgomesma - https://github.com/dgomesma/vladpiler
-- Braayy - https://github.com/Braayy/binha
+| Participante | Repositório | Status do projeto | Redes sociais |
+|---|---|---|---|---|
+| eduhenke | [rinha-de-compiler](https://github.com/eduhenke/rinha-de-compiler) | | |
+| eduOliver | [Rinha-Compiler](https://github.com/Edu0liver/Rinha-Compiler) | | |
+| henri | [rinha](https://github.com/hnrbs/rinha) | | |
+| edusporto | [rinha-compilador](https://github.com/edusporto/rinha-compilador) | | |
+| losty17 | [rinha-de-compiler](https://github.com/Losty17/rinha-de-compiler) | | |
+| rodrigocam | [rinha](https://github.com/rodrigocam/rinha) | | |
+| ricardopieper | [rinha-compiler](https://github.com/ricardopieper/rinha-compiler) | | |
+| adilsxn | [rinha-de-compiler](https://github.com/adilsxn/rinha-de-compiler) | | |
+| leonardohn | [rinha-interpreter](https://github.com/leonardohn/rinha-interpreter) | | |
+| lucasmontano | [rinha-de-compiler](https://github.com/lucasmontano/rinha-de-compiler) | | |
+| D4yvid | [compiler-rinha](https://github.com/D4yvid/compiler-rinha) | | |
+| Olordecoelho | [rinha-de-compiladores](https://github.com/olordecoelho/rinha-de-compiladores) | | |
+| DouglasGabr | [rinha-de-compiler](https://github.com/DouglasGabr/rinha-de-compiler) | | |
+| milyth | [touka](https://github.com/milyth/touka) | | |
+| italo | [rinha-compiler](https://github.com/ZyllDev/rinha-compiler) | | |
+| astahjmo e niumxp | [rinha-de-compiler](https://github.com/astahjmo/rinha-de-compiler) | | |
+| andrecoelho | [rinha-interpreter-app](https://github.com/andrecoelhoa/rinha-interpreter-app) | | |
+| Emanuel Júnior | [rinha-de-compiler](https://github.com/VetusScientia/rinha-de-compiler) | | |
+| Lamadelrae | [compiler-battles-csharp](https://github.com/Lamadelrae/compiler-battles-csharp) | | |
+| rwillians_ | [rinha-de-compiladores--gambi-elixir](https://github.com/rwillians/rinha-de-compiladores--gambi-elixir) | | |
+| wilgnne | [rinha-de-compiler-ts](https://github.com/wilgnne/rinha-de-compiler-ts) | | |
+| BRonen | [luajit-rinha-de-compiler](https://github.com/BRonen/luajit-rinha-de-compiler) | | |
+| netodotcom | [rinha-de-compiler](https://github.com/netodotcom/rinha-de-compiler) | | |
+| mr-soulfox | [rinha-de-compiladores-cpp](https://github.com/mr-soulfox/rinha-de-compiladores-cpp) | | |
+| Crazynds | [rinha-compiler](https://github.com/crazynds/rinha-compiler) | | |
+| reonardoleis | [nargas](https://github.com/reonardoleis/nargas) | | |
+| Yazalde Filimone | [rinha-compiler](https://github.com/yazaldefilimonepinto/rinha-compiler) | | |
+| PedroFnseca | [rinha-compiler-rust](https://github.com/PedroFnseca/rinha-compiler-rust) | | |
+| guilhermedjr | [rinha-compiler-csharp](https://github.com/guilhermedjr/rinha-compiler-csharp) | | |
+| dhrleandro | [rinha-de-compiler-php](https://github.com/dhrleandro/rinha-de-compiler-php) | | |
+| brunokim | [rinha-de-compiler](https://github.com/brunokim/rinha-de-compiler) | Tree-walking interpreter | [Mastodon](https://mastodon.social/@bkim) |
+| matheusgb | [marmota](https://github.com/matheusgb/marmota) | | |
+| lrlucena | [rinha-de-compiler-scala](https://github.com/lrlucena/rinha-de-compiler-scala) | | |
+| fernandozanutto | [rinha-compiler](https://github.com/fernandozanutto/rinha-compiler) | | |
+| fenner | [rinha-compiladores-2023](https://github.com/alexandrofenner/rinha-compiladores-2023) | | |
+| dgomesma | [vladpiler](https://github.com/dgomesma/vladpiler) | | |
+| Braayy | [binha](https://github.com/Braayy/binha) | | |

--- a/PARTICIPANTS.md
+++ b/PARTICIPANTS.md
@@ -1,7 +1,7 @@
 # Participantes
 
 | Participante | Repositório | Status do projeto | Redes sociais |
-|---|---|---|---|---|
+|---|---|---|---|
 | eduhenke | [rinha-de-compiler](https://github.com/eduhenke/rinha-de-compiler) | | |
 | eduOliver | [Rinha-Compiler](https://github.com/Edu0liver/Rinha-Compiler) | | |
 | henri | [rinha](https://github.com/hnrbs/rinha) | | |


### PR DESCRIPTION
# O quê

Usa uma tabela para listar os participantes ao invés de uma lista

# Por quê

Fix #18: permite colocar o estado do projeto

Também vi um comentário que o objetivo de mudar a listas de participantes para Markdown seria para podermos compartilhar nossas redes sociais.

# Notas

Acho que vai ficar mais bonitinho colocar os ícones de redes sociais do que o nome, mas isso podemos ver depois, dependendo das redes que o pessoal usa