### PR TITLE
Adicionado campos na tabela de participantes

### DIFF
--- a/PARTICIPANTS.md
+++ b/PARTICIPANTS.md
@@ -1,47 +1,53 @@
 # Participantes
 
-| Participante | Repositório | Status do projeto | Redes sociais |
-|---|---|---|---|
-| eduhenke | [rinha-de-compiler](https://github.com/eduhenke/rinha-de-compiler) | | |
-| eduOliver | [Rinha-Compiler](https://github.com/Edu0liver/Rinha-Compiler) | | |
-| henri | [rinha](https://github.com/hnrbs/rinha) | | |
-| edusporto | [rinha-compilador](https://github.com/edusporto/rinha-compilador) | | |
-| losty17 | [rinha-de-compiler](https://github.com/Losty17/rinha-de-compiler) | | |
-| rodrigocam | [rinha](https://github.com/rodrigocam/rinha) | | |
-| ricardopieper | [rinha-compiler](https://github.com/ricardopieper/rinha-compiler) | | |
-| adilsxn | [rinha-de-compiler](https://github.com/adilsxn/rinha-de-compiler) | | |
-| leonardohn | [rinha-interpreter](https://github.com/leonardohn/rinha-interpreter) | | |
-| lucasmontano | [rinha-de-compiler](https://github.com/lucasmontano/rinha-de-compiler) | | |
-| D4yvid | [compiler-rinha](https://github.com/D4yvid/compiler-rinha) | | |
-| Olordecoelho | [rinha-de-compiladores](https://github.com/olordecoelho/rinha-de-compiladores) | | |
-| DouglasGabr | [rinha-de-compiler](https://github.com/DouglasGabr/rinha-de-compiler) | | |
-| milyth | [touka](https://github.com/milyth/touka) | | |
-| italo | [rinha-compiler](https://github.com/ZyllDev/rinha-compiler) | | |
-| astahjmo e niumxp | [rinha-de-compiler](https://github.com/astahjmo/rinha-de-compiler) | | |
-| andrecoelho | [rinha-interpreter-app](https://github.com/andrecoelhoa/rinha-interpreter-app) | | |
-| Emanuel Júnior | [rinha-de-compiler](https://github.com/VetusScientia/rinha-de-compiler) | | |
-| Lamadelrae | [compiler-battles-csharp](https://github.com/Lamadelrae/compiler-battles-csharp) | | |
-| rwillians_ | [rinha-de-compilers--elixir-transpiler](https://github.com/rwillians/rinha-de-compilers--elixir-transpiler) | 🚧 wip | 𝕏 [@rwillians_](https://twitter.com/rwillians_) |
-| wilgnne | [rinha-de-compiler-ts](https://github.com/wilgnne/rinha-de-compiler-ts) | | |
-| BRonen | [luajit-rinha-de-compiler](https://github.com/BRonen/luajit-rinha-de-compiler) | | |
-| netodotcom | [rinha-de-compiler](https://github.com/netodotcom/rinha-de-compiler) | | |
-| mr-soulfox | [rinha-de-compiladores-cpp](https://github.com/mr-soulfox/rinha-de-compiladores-cpp) | | |
-| Crazynds | [rinha-compiler](https://github.com/crazynds/rinha-compiler) | | |
-| reonardoleis | [nargas](https://github.com/reonardoleis/nargas) | | |
-| Yazalde Filimone | [rinha-compiler](https://github.com/yazaldefilimonepinto/rinha-compiler) | | |
-| PedroFnseca | [rinha-compiler-rust](https://github.com/PedroFnseca/rinha-compiler-rust) | | |
-| guilhermedjr | [rinha-compiler-csharp](https://github.com/guilhermedjr/rinha-compiler-csharp) | | |
-| dhrleandro | [rinha-de-compiler-php](https://github.com/dhrleandro/rinha-de-compiler-php) | | |
-| brunokim | [rinha-de-compiler](https://github.com/brunokim/rinha-de-compiler) | Tree-walking interpreter | [Mastodon](https://mastodon.social/@bkim) |
-| matheusgb | [marmota](https://github.com/matheusgb/marmota) | | |
-| lrlucena | [rinha-de-compiler-scala](https://github.com/lrlucena/rinha-de-compiler-scala) | | |
-| fernandozanutto | [rinha-compiler](https://github.com/fernandozanutto/rinha-compiler) | | |
-| fenner | [rinha-compiladores-2023](https://github.com/alexandrofenner/rinha-compiladores-2023) | | |
-| dgomesma | [vladpiler](https://github.com/dgomesma/vladpiler) | | |
-| Braayy | [binha](https://github.com/Braayy/binha) | | |
-| guitcastro | https://github.com/guitcastro/rinha-de-compiler-ex | | |
-| RRFreitas | https://github.com/RRFreitas/Rinha-Compiler | | |
-| samueldurantes | https://github.com/samueldurantes/rinha | | |
-| dlopes7 | [dlopes7](https://github.com/dlopes7/rinha-compilers) | | |
-| renatoalencar | [rinha-de-compiladores-ocaml](https://github.com/renatoalencar/rinha-de-compiladores-ocaml) | | |
-| dhilst | https://github.com/dhilst/rinhacompiler | | |
+| Participante | Repositório | Status | Linguagem | Tipo do projeto | Redes sociais |
+|:-------------|:------------|:------:|:----------|:----------------|:--------------|
+| eduhenke | [rinha-de-compiler](https://github.com/eduhenke/rinha-de-compiler) | | | | |
+| eduOliver | [Rinha-Compiler](https://github.com/Edu0liver/Rinha-Compiler) | | | | |
+| henri | [rinha](https://github.com/hnrbs/rinha) | | | | |
+| edusporto | [rinha-compilador](https://github.com/edusporto/rinha-compilador) | | | | |
+| losty17 | [rinha-de-compiler](https://github.com/Losty17/rinha-de-compiler) | | | | |
+| rodrigocam | [rinha](https://github.com/rodrigocam/rinha) | | | | |
+| ricardopieper | [rinha-compiler](https://github.com/ricardopieper/rinha-compiler) | | | | |
+| adilsxn | [rinha-de-compiler](https://github.com/adilsxn/rinha-de-compiler) | | | | |
+| leonardohn | [rinha-interpreter](https://github.com/leonardohn/rinha-interpreter) | | | | |
+| lucasmontano | [rinha-de-compiler](https://github.com/lucasmontano/rinha-de-compiler) | | | | |
+| D4yvid | [compiler-rinha](https://github.com/D4yvid/compiler-rinha) | | | | |
+| Olordecoelho | [rinha-de-compiladores](https://github.com/olordecoelho/rinha-de-compiladores) | | | | |
+| DouglasGabr | [rinha-de-compiler](https://github.com/DouglasGabr/rinha-de-compiler) | | | | |
+| milyth | [touka](https://github.com/milyth/touka) | | | | |
+| italo | [rinha-compiler](https://github.com/ZyllDev/rinha-compiler) | | | | |
+| astahjmo e niumxp | [rinha-de-compiler](https://github.com/astahjmo/rinha-de-compiler) | | | | |
+| andrecoelho | [rinha-interpreter-app](https://github.com/andrecoelhoa/rinha-interpreter-app) | | | | |
+| Emanuel Júnior | [rinha-de-compiler](https://github.com/VetusScientia/rinha-de-compiler) | | | | |
+| Lamadelrae | [compiler-battles-csharp](https://github.com/Lamadelrae/compiler-battles-csharp) | | | | |
+| rwillians_ | [rinha-de-compiladores--gambi-elixir](https://github.com/rwillians/rinha-de-compiladores--gambi-elixir) | | | | |
+| wilgnne | [rinha-de-compiler-ts](https://github.com/wilgnne/rinha-de-compiler-ts) | | | | |
+| BRonen | [luajit-rinha-de-compiler](https://github.com/BRonen/luajit-rinha-de-compiler) | | | | |
+| netodotcom | [rinha-de-compiler](https://github.com/netodotcom/rinha-de-compiler) | | | | |
+| mr-soulfox | [rinha-de-compiladores-cpp](https://github.com/mr-soulfox/rinha-de-compiladores-cpp) | | | | |
+| Crazynds | [rinha-compiler](https://github.com/crazynds/rinha-compiler) | | | | |
+| reonardoleis | [nargas](https://github.com/reonardoleis/nargas) | | | | |
+| Yazalde Filimone | [rinha-compiler](https://github.com/yazaldefilimonepinto/rinha-compiler) | | | | |
+| PedroFnseca | [rinha-compiler-rust](https://github.com/PedroFnseca/rinha-compiler-rust) | | | | |
+| guilhermedjr | [rinha-compiler-csharp](https://github.com/guilhermedjr/rinha-compiler-csharp) | | | | |
+| dhrleandro | [rinha-de-compiler-php](https://github.com/dhrleandro/rinha-de-compiler-php) | | | | |
+| brunokim | [rinha-de-compiler](https://github.com/brunokim/rinha-de-compiler) | | | Tree-walking interpreter | [Mastodon](https://mastodon.social/@bkim) |
+| matheusgb | [marmota](https://github.com/matheusgb/marmota) | | | | |
+| lrlucena | [rinha-de-compiler-scala](https://github.com/lrlucena/rinha-de-compiler-scala) | | | | |
+| fernandozanutto | [rinha-compiler](https://github.com/fernandozanutto/rinha-compiler) | | | | |
+| fenner | [rinha-compiladores-2023](https://github.com/alexandrofenner/rinha-compiladores-2023) | | | | |
+| dgomesma | [vladpiler](https://github.com/dgomesma/vladpiler) | | | | |
+| Braayy | [binha](https://github.com/Braayy/binha) | | | | |
+| guitcastro | [rinha-de-compiler-ex](https://github.com/guitcastro/rinha-de-compiler-ex) | | | | |
+| RRFreitas | [Rinha-Compiler](https://github.com/RRFreitas/Rinha-Compiler) | | | | |
+| renatoalencar | [rinha-de-compiladores-ocaml](https://github.com/renatoalencar/rinha-de-compiladores-ocaml) | | | | |
+| dhilst | [rinhacompiler](https://github.com/dhilst/rinhacompiler) | | | | |
+
+
+**Tipos de projeto:**
+| Nome                       | Descrição / Link para recursos explicando       |
+|:---------------------------|:------------------------------------------------|
+| Tree-walking Interpretador | `n/a`                                           |
+
+_(Caso seu tipo de projeto não esteja nessa tabela, por favor adicione.)_


### PR DESCRIPTION
Campos alterados:
- Adicionado `Linguagem`: se refere a linguagem de programação (ou ferramenta, caso se aplique) utilizada para implementar o projeto. Essa foi uma informação MUITO solicitada  na rinha de backend porém não tínhamos essa info fácil, tínhamos que abrir repo por repo;
- Renomeado `Status do projeto`: renomeado para `Status` para economizar espaço;
- Adicionado `Tipo do projeto`: podem haver diferentes tipos de projeto, por exemplo, algumas pessoas podem preferir escrever lexer+parser+compiler+runtime tudo na mão, outras podem fazer um interpreter e outras, como meu caso, podem fazer apenas um transpiler, etc. Acredito que listar o tipo do projeto seja uma informação muito relevante para posterioridade. Assim, pessoas olhando essa tabela buscando aprender com os projetos participantes podem facilmente escolher qual projeto olhar com base no tipo do projeto.