### PR TITLE
Removido espaço extra na chamada de função

### DIFF
--- a/files/fib.rinha
+++ b/files/fib.rinha
@@ -6,4 +6,4 @@ let fib = fn (n) => {
   }
 };
 
-print (fib(10))
+print(fib(10))


### PR DESCRIPTION
Não sei se foi intencional, mas tinha um espaço adicional na chamada do `print`. Já no arquivo `combination.rinha` não tem esse espaço, então imagino que possa ter sido um errinho de digitação. Para economizar um lookahead, estou removendo o espaço.

Caso tenha sido intencional, para testar a resiliência do parser, por favor ignorar esse PR.