### PR TITLE
SPECS.md -- especificação mais detalhada de `Print`

### DIFF
--- a/SPECS.md
+++ b/SPECS.md
@@ -278,6 +278,17 @@ Os valores devem ser impressos como:
 | Closure | `<#closure>`                     |
 | Tuple   | `(term, term)`                   |
 
+`Print` retorna o valor que foi passado. A saída adiciona ao final um caractere de nova linha (LF - 0x0A).
+
+Em termos compostos, chamadas a `Print` devem ocorrer na ordem em que aparecem na AST. Por exemplo:
+
+| Código | Como deve ser printado (`\n` é o caractere LF) |
+| ------ | -----------------------------------------------|
+| `let _ = print(1); print(2)` | `1\n2\n` |
+| `f(print(1), print(2), print(3))` | `1\n2\n3\n` |
+| `let tuple = (print(1), print(2)); print(tuple)` | `1\n2\n(1, 2)\n` |
+| `print(print(1) + print(2))` | `1\n2\n3\n` |
+
 ### Term
 
 Um termo pode ser qualquer uma das seguintes estruturas:


### PR DESCRIPTION
Fix #120: adiciona informações sobre o retorno de `Print`.

Incluí também outras especificações que fazem sentido pra mim, mas que vocês podem ter uma opinião diferente. Se não for o plano adicioná-las, eu retiro da PR.

## Adicionar ou não um newline ao final: *sim*.

Particularmente eu preferiria que não, mas todos os exemplos dão a entender que é o esperado.

## Ordem de saída: *seguindo a AST*

Eu imagino que a maioria nem pensaria em execução de argumentos fora de ordem, mas é uma possibilidade que precisa ser especificada

## Memoização de print: *não especificado*

Eu não incluí no texto porque vejo várias opções e gostaria de discutir antes:

1. `Print` *sempre* deve produzir saída: exige que quem implementar memoização de chamadas também inclua o stdout como resultado.
1. `Print` deve produzir *pelo menos uma* saída: é o mais natural pra quem implementa memoização, imprimindo quando realizar a execução e não imprimindo quando usar o cache. Este caso proíbe omitir um print em caso de otimização, por exemplo, `if print(false) { 1 } else { 2 }` não poderia ser transformado para `2`, porque isso omite o `print(false)`.
1. O comportamento do `Print` *depende da implementação*: nesse caso, a validação não pode exigir que um `Print` seja executado nem mesmo uma vez, podendo ser até mesmo um noop. A validação deveria ocorrer pelo valor de saída do programa.